### PR TITLE
Resolve Phantom Dependency problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@codemirror/lang-javascript": "^6.0.0",
     "@codemirror/language": "^6.0.0",
     "@codemirror/state": "^6.0.0",
-    "@lezer/html": "^1.0.0",
+    "@lezer/html": "^1.0.1",
     "@lezer/common": "^1.0.0",
     "@codemirror/view": "^6.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "@codemirror/language": "^6.0.0",
     "@codemirror/state": "^6.0.0",
     "@lezer/html": "^1.0.0",
-    "@lezer/common": "^1.0.0"
+    "@lezer/common": "^1.0.0",
+    "@codemirror/view": "^6.2.2"
   },
   "devDependencies": {
     "@codemirror/buildhelper": "^0.1.5"


### PR DESCRIPTION
I'm having two issues related Phantom Dependency in Yarn berry:

```
✘ [ERROR] Could not resolve "@codemirror/view"

    ../../node_modules/.store/@codemirror-lang-html-npm-6.1.0-c047364f83/node_modules/@codemirror/lang-html/dist/index.js:4:27:
      4 │ import { EditorView } from '@codemirror/view';
        ╵                            ~~~~~~~~~~~~~~~~~~
```

⬆️ In [`HEAD/src/html.ts#L4`](https://github.com/codemirror/lang-html/blob/afd2e86f/src/html.ts#L4) referring `@codemirror/view` but the package isn't included in the `package.json`.

```
✘ [ERROR] Could not resolve "@lezer/common"

    ../../node_modules/.store/@lezer-html-npm-1.0.0-f4e61d2cf6/node_modules/@lezer/html/dist/index.es.js:3:27:
      3 │ import { parseMixed } from '@lezer/common';
        ╵                            ~~~~~~~~~~~~~~~
```

⬆️ This issue has been resolved in  `@lezer/html@1.0.1`, so I suggest upgrading.

---

Yarn berry is a package manager that blocks [phantom dependency](https://rushjs.io/pages/advanced/phantom_deps/) issues. 

- For npm or yarn classic users, this is a problem you won't run into
- if you're using a Yarn berry(v2~) that completely blocks Phantom dependencies, you can't avoid it

If possible, I would like to upgrade to a version that fixes this problem and use it.. 🥺 

---

### Additional proposals: Package lock files

How about create `package-lock.json` or `yarn.lock` as a [lock file](https://nodejs.dev/en/learn/the-package-lockjson-file/)?