### PR TITLE
Make auto-closing tag consume following closing angle bracket

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -102,13 +102,18 @@ export const autoCloseTags = EditorView.inputHandler.of((view, from, to, text) =
     let {head} = range, around = syntaxTree(state).resolveInner(head, -1), name
     if (around.name == "TagName" || around.name == "StartTag") around = around.parent!
     if (text == ">" && around.name == "OpenTag") {
-      if (around.parent?.lastChild?.name != "CloseTag" && (name = elementName(state.doc, around.parent, head)))
-        return {range: EditorSelection.cursor(head + 1), changes: {from: head, insert: `></${name}>`}}
+      if (around.parent?.lastChild?.name != "CloseTag" && (name = elementName(state.doc, around.parent, head))) {
+        let hasRightBracket = view.state.doc.sliceString(head, head + 1) === ">";
+        let insert = `${hasRightBracket ? "" : ">"}</${name}>`
+        return {range: EditorSelection.cursor(head + 1), changes: {from: head + (hasRightBracket ? 1 : 0), insert}}
+      }
     } else if (text == "/" && around.name == "OpenTag") {
       let empty = around.parent, base = empty?.parent
       if (empty!.from == head - 1 && base!.lastChild?.name != "CloseTag" && (name = elementName(state.doc, base, head))) {
-        let insert = `/${name}>`
-        return {range: EditorSelection.cursor(head + insert.length), changes: {from: head, insert}}
+        let hasRightBracket = view.state.doc.sliceString(head, head + 1) === ">"
+        let insert = `/${name}${hasRightBracket ? "" : ">"}`
+        let pos = head + insert.length + (hasRightBracket ? 1 : 0) 
+        return {range: EditorSelection.cursor(pos), changes: {from: head, insert}}
       }
     }
     return {range}


### PR DESCRIPTION
This changes the behavior of `autoClosingTag` extension take into account leading `>`, it consumes the `>` instead of adding a new one.

I found this behavior to be more sane as I'm writing code inside codemirror.

Here's a video of the interaction

https://user-images.githubusercontent.com/1994028/192403206-94ef735b-d1e0-4cfa-98c2-c63481e21e7f.mp4



And here's a before interaction


https://user-images.githubusercontent.com/1994028/192403216-8e4e2f3f-2ee2-4793-a567-11444c32fe9b.mp4


