### PR TITLE
Also support type=text/babel for <script> tags.

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -19,7 +19,7 @@ const defaultNesting: NestedLang[] = [
    attrs: attrs => attrs.type == "text/typescript" || attrs.lang == "ts",
    parser: typescriptLanguage.parser},
   {tag: "script",
-   attrs: attrs => attrs.type == "text/jsx",
+   attrs: attrs => attrs.type == "text/babel" || attrs.type == "text/jsx",
    parser: jsxLanguage.parser},
   {tag: "script",
    attrs: attrs => attrs.type == "text/typescript-jsx",


### PR DESCRIPTION
Both the official React documentation[^1] as well as the official Babel documentation[^2] still mention `type=text/babel` as an alternative to `type=text/jsx`, so it makes sense for us to support as well for the purpose of syntax highlighting.

[^1]: https://reactjs.org/docs/add-react-to-a-website.html#quickly-try-jsx
[^2]: https://babeljs.io/docs/en/babel-standalone#script-tags