### PR TITLE
Add support for type=application/json in HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@codemirror/autocomplete": "^6.0.0",
     "@codemirror/lang-css": "^6.0.0",
     "@codemirror/lang-javascript": "^6.0.0",
+    "@codemirror/lang-json": "^6.0.1",
     "@codemirror/language": "^6.0.0",
     "@codemirror/state": "^6.0.0",
     "@lezer/html": "^1.1.0",


### PR DESCRIPTION
On Facebook, we use application/json script tags (open HTML source on facebook.com logged in), and would like to enable syntax highlighting and code folding . I opened a PR for devtools to add pretty printing, but was directed here for adding the highlighting/parsing by @bmeurer  (see https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/4047809 ).

This adds that support (hopefully)