### PR TITLE
Parse <script type=application/json> as JSON

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -28,7 +28,9 @@ const defaultNesting: NestedLang[] = [
    attrs: attrs => attrs.type == "text/typescript-jsx",
    parser: tsxLanguage.parser},
   {tag: "script",
-   attrs: attrs => attrs.type == "importmap" || attrs.type == "speculationrules",
+   attrs(attrs) {
+     return /^(importmap|speculationrules|application\/(.+\+)?json)$/i.test(attrs.type)
+   },
    parser: jsonParser},
   {tag: "script",
    attrs(attrs) {


### PR DESCRIPTION
This extends 3fd4636e9b66438c1504bcc166a6bf0b117c0c6f to also support application/json and subtypes of it as JSON.

Ref: https://crbug.com/1505381